### PR TITLE
Makes the compiled code universal

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
         "strictNullChecks": true,
         "moduleResolution": "node",
         "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
         "experimentalDecorators": true,
         "noUnusedParameters": true,
         "noUnusedLocals": false,


### PR DESCRIPTION
Since this package is published as a compiled code there may be some problems to bundle it with a standalone library and  you cannot be sure that the esm version will be used.

1st option is to set `esModuleInterop` so we get the following code:

```index.js
// compiled index.js
"use strict";
var __importDefault = (this && this.__importDefault) || function (mod) {
    return (mod && mod.__esModule) ? mod : { "default": mod };
}
Object.defineProperty(exports, "__esModule", { value: true });
var vue_1 = __importDefault(require("vue"));
exports.Vue = vue_1.default;
exports.VueComponent = vue_1.default;
```
without any change of source code.

2nd options is to refactor the import without configuration of typescript:
```index.ts
// source index.ts
import * as Vue from "vue";

exports.Vue = Vue;

exports.VueComponent = Vue;
```
to get:

```index.js
// compiled index.js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
var Vue = require("vue");
exports.Vue = Vue;
exports.VueComponent = Vue;
```