### PR TITLE
Make `_children_` attribute optional

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -11,7 +11,7 @@ declare namespace InternalJSX {
     };
 
     interface ElementAdditionalAttrs {
-        _children_: any;
+        _children_?: any;
     }
 
     type EventHandlers<E> = { [K in keyof E]?: (payload: E[K]) => void };


### PR DESCRIPTION
Not all elements have children.