### PR TITLE
Set the rest properties of components supported by Vue

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -4,7 +4,7 @@ import * as Dom from "./dom";
 declare namespace InternalJSX {
     type KnownAttrs = Pick<
         VNodeData,
-        "class" | "staticClass" | "style" | "key" | "ref" | "slot" | "scopedSlots"
+        "class" | "staticClass" | "style" | "key" | "ref" | "slot" | "scopedSlots" | "props" | "attrs" | "on" | "nativeOn" | "directives"
     > & {
         id?: string;
         refInFor?: boolean;


### PR DESCRIPTION
There are extra properties of Data Object supported by VUE JSX https://vuejs.org/v2/guide/render-function.html#The-Data-Object-In-Depth 

Developer may face edge cases where these properties be useful. For example, avoid collision of names with built-in (reserved) names.

Right now, the absence of these properties is causing an error:
<img width="1090" alt="Screen Shot 2020-05-22 at 5 24 57 PM" src="https://user-images.githubusercontent.com/365720/82678289-05655600-9c52-11ea-9ac5-12c4d3b8ef35.png">

There is a workaround with `spread` operator to avoid this:

<img width="381" alt="Screen Shot 2020-05-22 at 5 24 13 PM" src="https://user-images.githubusercontent.com/365720/82679598-ce903f80-9c53-11ea-9f7a-7c5c0c32f0b7.png">


But this solution brings extra cost at runtime (below you can see the transpiled code):

<img width="381" alt="Screen Shot 2020-05-22 at 5 25 57 PM" src="https://user-images.githubusercontent.com/365720/82678854-01860380-9c53-11ea-8d91-89e2eb8afcf6.png">

Where `_objectSpread2` is:
<img width="788" alt="Screen Shot 2020-05-22 at 5 26 11 PM" src="https://user-images.githubusercontent.com/365720/82678927-20849580-9c53-11ea-8cd8-cb49abf2d505.png">

I suggest adding the properties as Known Attributes (in any case, they will be handled in a special way by vue).

Thank you.